### PR TITLE
Add JAX/Flax and associated ML dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,17 @@ keywords = [
 dependencies = [
   # Install swirl-dynamics from a specific commit.
   "swirl-dynamics @ git+https://github.com/google-research/swirl-dynamics.git@057c93cebc3c8ccac996bc5a5b49c88e3e39c4b0",
+  "jax==0.5.0",
+  "jaxlib==0.5.0",
+  "flax<0.11",
+  "optax<0.2.5",
+  "chex<0.1.90",
+  "orbax-checkpoint<0.11",
+  "lineax<0.0.8",
+  "clu",
+  "tensorboard",
+  "ml-collections",
+  "absl-py",
   "jupyter",
   "matplotlib",
   "natsort",


### PR DESCRIPTION
### Motivation

- The project requires the JAX ecosystem and common ML utilities to run and train diffusion models and to interact with `swirl-dynamics`-based code. 
- Specific version pins are added to ensure compatibility between `jax`, `jaxlib`, and other libraries used by the codebase.

### Description

- Updated `pyproject.toml` to add runtime dependencies including `jax==0.5.0`, `jaxlib==0.5.0`, `flax<0.11`, `optax<0.2.5`, `chex<0.1.90`, `orbax-checkpoint<0.11`, and `lineax<0.0.8`.
- Added common tooling and utilities as dependencies including `clu`, `tensorboard`, `ml-collections`, and `absl-py` to support training, configuration, and logging.
- Preserved the existing pinned `swirl-dynamics` VCS dependency and other scientific/runtime dependencies such as `ott-jax` and plotting/notebook packages.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3fbba034832a840b7b88919cec4a)