### PR TITLE
Fix README heading typo and remove unused import from fstars.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This framework produces highly accurate reconstructions, leveraging conditional 
 
 These two steps individually obey their associated symmetries and are amenable to compression by imposing the rank structure found in the filtered back-projection formula. Empirically, our framework has both low sample and computational complexity, with its number of parameters scaling only sub-linearly with the target resolution, and has stable training dynamics. It provides sharp reconstructions effortlessly and is capable of recovering even sub-Nyquist features in the multiple-scattering regime.
 
-## Enviroment Setup
+## Environment Setup
 Project Environment can be installed by 
 ```
 conda create -n back_projection_diffusion python=3.11 

--- a/back_projection_diffusion/src/fstars.py
+++ b/back_projection_diffusion/src/fstars.py
@@ -3,7 +3,6 @@ import jax
 import jax.numpy as jnp
 from jax.experimental import sparse
 import flax.linen as nn
-from numpy import cos, sin, exp, newaxis
 
 
 class AnalyticalFstar(nn.Module):


### PR DESCRIPTION
### Motivation
- Improve project hygiene and readability by correcting a README section heading and removing a dead import that can trigger linter noise.

### Description
- Correct the README section title from `Enviroment Setup` to `Environment Setup` and remove the unused `from numpy import cos, sin, exp, newaxis` import from `back_projection_diffusion/src/fstars.py`.

### Testing
- Ran `python -m compileall back_projection_diffusion/src` to ensure the package compiles, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc45b28c6c832a9057eae7236c9a18)