### PR TITLE
Shuffle dataset in create_dataset to ensure randomized batches

### DIFF
--- a/back_projection_diffusion/src/utils.py
+++ b/back_projection_diffusion/src/utils.py
@@ -261,7 +261,7 @@ def create_dataset(eta: np.ndarray, scatter: np.ndarray, batch_size: int,
   """Creates a tensorflow dataset from eta and scatter data.
 
   The dictionary 'x' contains the eta data and 'cond' contains the scatter
-  channels.
+  channels. The dataset is shuffled before batching.
 
   Args:
     eta: Array containing eta data.
@@ -281,6 +281,7 @@ def create_dataset(eta: np.ndarray, scatter: np.ndarray, batch_size: int,
     }
   }
   dataset = tf.data.Dataset.from_tensor_slices(dict_data)
+  dataset = dataset.shuffle(buffer_size=eta.shape[0], reshuffle_each_iteration=True)
   if repeat:
     dataset = dataset.repeat()
   dataset = dataset.batch(batch_size)


### PR DESCRIPTION
### Motivation
- Ensure training data is randomized each epoch so batches are not presented in a fixed order during training.

### Description
- Add a shuffle step to `create_dataset` in `back_projection_diffusion/src/utils.py` by calling `dataset.shuffle(buffer_size=eta.shape[0], reshuffle_each_iteration=True)` and update the docstring to note that the dataset is shuffled before batching.

### Testing
- Ran the project test suite with `pytest` and verified no test regressions occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc66a25fb8832ab9ff73567ea6b2ce)