### PR TITLE
Shuffle dataset in create_dataset when repeating (train mode)

### DIFF
--- a/back_projection_diffusion/src/utils.py
+++ b/back_projection_diffusion/src/utils.py
@@ -261,7 +261,7 @@ def create_dataset(eta: np.ndarray, scatter: np.ndarray, batch_size: int,
   """Creates a tensorflow dataset from eta and scatter data.
 
   The dictionary 'x' contains the eta data and 'cond' contains the scatter
-  channels.
+  channels. When repeat=True (training), the dataset is shuffled before batching.
 
   Args:
     eta: Array containing eta data.
@@ -282,6 +282,9 @@ def create_dataset(eta: np.ndarray, scatter: np.ndarray, batch_size: int,
   }
   dataset = tf.data.Dataset.from_tensor_slices(dict_data)
   if repeat:
+    dataset = dataset.shuffle(
+      buffer_size=eta.shape[0], reshuffle_each_iteration=True
+    )
     dataset = dataset.repeat()
   dataset = dataset.batch(batch_size)
   dataset = dataset.prefetch(tf.data.AUTOTUNE)


### PR DESCRIPTION
### Motivation

- Ensure the training dataset is randomized across epochs by shuffling before repeating and batching to avoid deterministic batch ordering when `repeat=True` in `create_dataset`.

### Description

- Add `dataset.shuffle(buffer_size=eta.shape[0], reshuffle_each_iteration=True)` to `create_dataset` when `repeat=True` and update the function docstring to note that the dataset is shuffled for training.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc66a25fb8832ab9ff73567ea6b2ce)