### PR TITLE
Reorganize headings in scattering_test notebook

### DIFF
--- a/data_generation/jax_forward_scattering/scattering_test.ipynb
+++ b/data_generation/jax_forward_scattering/scattering_test.ipynb
@@ -6,7 +6,7 @@
     "id": "JP6GQNwnCrwz"
    },
    "source": [
-    "## Imports"
+    "## Setup & Imports\n"
    ]
   },
   {
@@ -34,7 +34,7 @@
     "id": "_U-O2msbGzEx"
    },
    "source": [
-    "### Dataset"
+    "## Load Dataset\n"
    ]
   },
   {
@@ -128,7 +128,7 @@
     "id": "6yOBMiJtG7r3"
    },
    "source": [
-    "### Architecture"
+    "## Scattering Operator Setup\n"
    ]
   },
   {
@@ -174,6 +174,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Forward Pass Comparison\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
@@ -212,6 +219,13 @@
    "source": [
     "plt.imshow((y[0, :, :, 2] - scatter[0, :, :, 2]).real)\n",
     "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Differential Operator Checks\n"
    ]
   },
   {
@@ -287,6 +301,13 @@
     "print(\"lhs =\", lhs)\n",
     "print(\"rhs =\", rhs)\n",
     "print(\"relative error =\", relerr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Jacobian/Adjoint Visual Diagnostics\n"
    ]
   },
   {


### PR DESCRIPTION
### Motivation
- Clarify and correct the notebook structure by replacing the incorrect `Architecture` heading and making the workflow stages explicit for easier human review and debugging of the `data_generation/jax_forward_scattering/scattering_test.ipynb` test notebook.

### Description
- Rename top-level headings to `## Setup & Imports` and `## Load Dataset`, replace `### Architecture` with `## Scattering Operator Setup`, and insert new section headers `## Forward Pass Comparison`, `## Differential Operator Checks`, and `## Jacobian/Adjoint Visual Diagnostics` to group validation cells.

### Testing
- Ran small automated scripts to inspect notebook headings before and after the change (via `python - <<'PY'` JSON inspection and update), programmatically updated `scattering_test.ipynb` and reloaded the JSON to confirm the file structure was modified as intended without runtime computation; the scripts completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002aafe298832a85cb31856033bf96)